### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/libucx/pyproject.toml
+++ b/python/libucx/pyproject.toml
@@ -15,7 +15,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 # Note: We can probably relax this, but it's not critical for now.
 requires-python = ">=3.9"
 classifiers = [


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
