### PR TITLE
fix wheel uploads

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -204,4 +204,4 @@ jobs:
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       run: |
-        rapids-upload-to-anaconda-github ucx cpp
+        rapids-wheels-anaconda-github ucx cpp


### PR DESCRIPTION
Followup to #23

Uploads there failed like this:

> no artifact matches any of the names or patterns provided

([build link](https://github.com/rapidsai/ucx-wheels/actions/runs/15007459757/job/42170494106))

Because I introduced the use of a conda-specific script (`rapids-upload-to-anaconda-github`) when we actually want the wheel-specific one (`rapids-wheels-anaconda-github`).

This should fix that.