### PR TITLE
Remove UCX-Py reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository hosts code for building wheels of [UCX](https://github.com/openucx/ucx/).
 
 ## Purpose
-RAPIDS publishes multiple libraries that rely on UCX, including [ucxx](https://github.com/rapidsai/ucxx/) and [ucx-py](https://github.com/rapidsai/ucx-py).
+RAPIDS publishes multiple libraries that rely on UCX, including [UCXX](https://github.com/rapidsai/ucxx/).
 One of the ways that RAPIDS vendors these libraries is in the form of [pip wheels](https://packaging.python.org/en/latest/specifications/binary-distribution-format/).
 For portability, wheels should be as self-contained as possible as per the [manylinux standard](https://peps.python.org/pep-0513/).
 However, the cost of this is (sometimes extreme) bloat as wheels must bundle all their dependencies.


### PR DESCRIPTION
UCX-Py is deprecated and is being archived (https://github.com/rapidsai/build-planning/issues/198), the reference contained in the README file should be removed.