### PR TITLE
use CUDA 13.0.1 CI images

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -63,10 +63,10 @@ jobs:
           export BUILD_MATRIX="
           # amd64
           - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'rockylinux8' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.0', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'rockylinux8' }
           # arm64
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'rockylinux8' }
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.0', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'rockylinux8' }
           "
 
           BUILD_MATRIX="$(
@@ -81,12 +81,12 @@ jobs:
           - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'earliest' }
           - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
           - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.0', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
           # arm64
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.0', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
           "
 
           TEST_MATRIX="$(


### PR DESCRIPTION
RAPIDS recently started building and testing against CUDA 13.0.1:

* https://github.com/rapidsai/ci-imgs/pull/304
* https://github.com/rapidsai/shared-workflows/pull/423

This updates hard-coded `13.0.0` references in some CI jobs to `13.0.1`.