### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,24 +1,25 @@
 name: build
-
 on:
   push:
     branches:
       - "main"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   version_changed:
     runs-on: ubuntu-latest
     name: Check if the version was bumped
     outputs:
       version_changed: ${{ steps.changed_files.outputs.version_changed }}
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check VERSION file for changes
         id: changed_files
         run: |
@@ -33,8 +34,13 @@ jobs:
           echo "version_changed=${has_changes}" >> "$GITHUB_OUTPUT"
   build_and_test:
     needs: version_changed
-    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/build_and_test.yaml
     with:
       build_type: branch
       publish_packages: ${{ needs.version_changed.outputs.version_changed }}
+    secrets:
+      nightly_wheel_token: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       pull-requests: read
     uses: ./.github/workflows/build_and_test.yaml
     with:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -12,7 +12,7 @@ on:
     secrets:
       nightly_wheel_token:
         required: true
-        description: "API toke for publishing to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
+        description: "API token for publishing to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
 
 permissions: {}
 
@@ -103,6 +103,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       pull-requests: read
     steps:
       - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,5 +1,4 @@
 name: build_and_test
-
 on:
   workflow_call:
     inputs:
@@ -10,33 +9,27 @@ on:
         required: false
         default: 'false'
         type: string
+    secrets:
+      nightly_wheel_token:
+        required: true
+        description: "API toke for publishing to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
 
-permissions:
-  actions: read
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: write
-  issues: none
-  packages: read
-  pages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: none
+permissions: {}
 
 jobs:
   checks:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:latest # zizmor: ignore[unpinned-images]
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-      - uses: actions/cache@v4
+          persist-credentials: false
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-0|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -50,6 +43,8 @@ jobs:
     outputs:
       BUILD_MATRIX: ${{ steps.compute-matrix.outputs.BUILD_MATRIX }}
       TEST_MATRIX: ${{ steps.compute-matrix.outputs.TEST_MATRIX }}
+    permissions:
+      contents: read
     steps:
       - name: Compute Build Matrix
         id: compute-matrix
@@ -96,7 +91,7 @@ jobs:
 
           echo "TEST_MATRIX=${TEST_MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   build:
-    name:  build-${{ matrix.CUDA_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
+    name: build-${{ matrix.CUDA_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
     needs: compute-matrices
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrices.outputs.BUILD_MATRIX) }}
@@ -105,14 +100,18 @@ jobs:
       image: "rapidsai/ci-wheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 900
       - name: checkout code repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Standardize repository information
@@ -137,10 +136,12 @@ jobs:
           echo "WHEEL_OUTPUT_DIR=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name
       - name: Show files to be uploaded
+        env:
+          WHEEL_OUTPUT_DIR: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
         run: |
           echo "Contents of directory to be uploaded:"
-          ls -R ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
-      - uses: actions/upload-artifact@v4
+          ls -R "${WHEEL_OUTPUT_DIR}"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
@@ -157,52 +158,60 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-        aws-region: ${{ vars.AWS_REGION }}
-        role-duration-seconds: 900
-    - name: Run nvidia-smi to make sure GPU is working
-      run: nvidia-smi
-    - name: checkout code repo
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - name: Standardize repository information
-      uses: rapidsai/shared-actions/rapids-github-info@main
-    - name: Run tests
-      run: ci/test_wheel.sh
-      env:
-        GH_TOKEN: ${{ github.token }}
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+      - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 900
+      - name: Run nvidia-smi to make sure GPU is working
+        run: nvidia-smi
+      - name: checkout code repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Standardize repository information
+        uses: rapidsai/shared-actions/rapids-github-info@main
+      - name: Run tests
+        run: ci/test_wheel.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
   publish:
     if: ${{ inputs.publish_packages == 'true' }}
     needs: test
     runs-on: linux-amd64-cpu4
     container:
-      image: "rapidsai/ci-wheel:latest"
+      image: "rapidsai/ci-wheel:latest" # zizmor: ignore[unpinned-images]
       env:
         GH_TOKEN: ${{ github.token }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-        aws-region: ${{ vars.AWS_REGION }}
-        role-duration-seconds: 900
-    - name: checkout code repo
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - name: Get current date
-      id: date
-      run: |
-        echo "CURRENT_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
-    - name: Standardize repository information
-      uses: rapidsai/shared-actions/rapids-github-info@main
-    - name: Download wheels from artifact storage and publish to anaconda repository
-      env:
-        RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
-      run: |
-        rapids-wheels-anaconda-github ucx cpp
+      - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 900
+      - name: checkout code repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Get current date
+        id: date
+        run: |
+          echo "CURRENT_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
+      - name: Standardize repository information
+        uses: rapidsai/shared-actions/rapids-github-info@main
+      - name: Download wheels from artifact storage and publish to anaconda repository
+        env:
+          RAPIDS_CONDA_TOKEN: ${{ secrets.nightly_wheel_token }}
+        run: |
+          rapids-wheels-anaconda-github ucx cpp

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -106,6 +106,7 @@ jobs:
       id-token: write
       pull-requests: read
     steps:
+      # AWS creds are needed here for sccache
       - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -164,11 +165,6 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
-          role-duration-seconds: 900
       - name: Run nvidia-smi to make sure GPU is working
         run: nvidia-smi
       - name: checkout code repo
@@ -196,11 +192,6 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
-          role-duration-seconds: 900
       - name: checkout code repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,12 +11,25 @@ jobs:
   pr-builder:
     needs:
       - build_and_test
+      - checks
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     permissions:
       contents: read
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
+  checks:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   build_and_test:
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,18 +1,20 @@
 name: pr
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
-
+permissions: {}
 jobs:
   build_and_test:
-    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/build_and_test.yaml
     with:
       build_type: pull-request
+    secrets:
+      nightly_wheel_token: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       pull-requests: read
     uses: ./.github/workflows/build_and_test.yaml
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,15 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  pr-builder:
+    needs:
+      - build_and_test
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    permissions:
+      contents: read
+    if: always()
+    with:
+      needs: ${{ toJSON(needs) }}
   build_and_test:
     permissions:
       actions: read

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,16 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
+    rev: 9.0.0a3
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.13
     hooks:
       - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.3
+    rev: v1.4.3
     hooks:
       - id: verify-copyright
       - id: verify-pyproject-license
@@ -25,6 +25,10 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor
 
 default_language_version:
   python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
+    rev: v0.15.15
     hooks:
       - id: ruff-check
       - id: ruff-format


### PR DESCRIPTION
Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Contributes to:

* https://github.com/rapidsai/build-planning/issues/275 
* https://github.com/rapidsai/ucx-wheels/issues/36