### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -63,10 +63,10 @@ jobs:
           export BUILD_MATRIX="
           # amd64
           - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'rockylinux8' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.2.0', LINUX_VER: 'rockylinux8' }
           # arm64
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'rockylinux8' }
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.2.0', LINUX_VER: 'rockylinux8' }
           "
 
           BUILD_MATRIX="$(

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -62,11 +62,11 @@ jobs:
           #
           export BUILD_MATRIX="
           # amd64
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'rockylinux8' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.2.0', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
           # arm64
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'rockylinux8' }
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.2.0', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
           "
 
           BUILD_MATRIX="$(

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -78,15 +78,15 @@ jobs:
 
           export TEST_MATRIX="
           # amd64
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'earliest' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
-          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'l4',   driver: 'earliest' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.2', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.3', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
+          - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.3.0', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
           # arm64
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
-          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.1', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.2', LINUX_VER: 'ubuntu22.04', gpu: 'a100', driver: 'earliest' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.3', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
+          - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.3.0', LINUX_VER: 'ubuntu24.04', gpu: 'a100', driver: 'latest' }
           "
 
           TEST_MATRIX="$(

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -205,4 +205,4 @@ jobs:
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       run: |
-        rapids-wheels-anaconda-github ucx cpp
+        rapids-download-from-github "$(rapids-artifact-name wheel_cpp libucx ucx --cuda "$RAPIDS_CUDA_VERSION")"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -21,3 +21,6 @@ python -m auditwheel repair             \
     ${package_dir}/dist/*
 
 ci/validate_wheel.sh "${package_dir}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_cpp libucx ucx --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -8,8 +8,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 package_name="libucx"
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="ucx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
+WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libucx ucx --cuda "$RAPIDS_CUDA_VERSION")")
 python -m pip install "${WHEELHOUSE}/${package_name}_${RAPIDS_PY_CUDA_SUFFIX}"*.whl
 
 # Test basic library loading


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270