### PR TITLE
update all pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.20
     hooks:
       - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.4.3
+    rev: v1.5.1
     hooks:
       - id: verify-copyright
       - id: verify-pyproject-license
@@ -26,7 +26,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.26.1
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
Contributes to #36 

Making a minor change (`pre-commit autoupdate`) mainly to get a PR running so GitHub's lists of PR status checks will update. That list needs to be updated to set up a branch protection that prevents merges if CI isn't passing.