### PR TITLE
automate publishing to PyPI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,3 +45,4 @@ jobs:
       publish_packages: ${{ needs.version_changed.outputs.version_changed }}
     secrets:
       nightly_wheel_token: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      pypi-token: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -184,7 +184,7 @@ jobs:
   publish:
     # TODO: revert this after 1.20.0 is published
     # if: ${{ inputs.publish_packages == 'true' }}
-    needs: test
+    # needs: test
     runs-on: linux-amd64-cpu4
     container:
       image: "rapidsai/ci-wheel:latest" # zizmor: ignore[unpinned-images]
@@ -211,6 +211,9 @@ jobs:
         env:
           RAPIDS_CONDA_TOKEN: ${{ secrets.nightly_wheel_token }}
         run: |
+          rapids-pip-retry install \
+            --prefer-binary \
+            'anaconda-client>=1.13.1'
           UPLOAD_DIR="$(mktemp -d)"
           rapids-wheels-anaconda-github ucx cpp "${UPLOAD_DIR}"
           echo "package_upload_dir=${UPLOAD_DIR}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -203,7 +203,18 @@ jobs:
       - name: Standardize repository information
         uses: rapidsai/shared-actions/rapids-github-info@main
       - name: Download wheels from artifact storage and publish to anaconda repository
+        id: download-wheels
         env:
           RAPIDS_CONDA_TOKEN: ${{ secrets.nightly_wheel_token }}
         run: |
-          rapids-wheels-anaconda-github ucx cpp
+          UPLOAD_DIR="$(mktemp -d)"
+          rapids-wheels-anaconda-github ucx cpp "${UPLOAD_DIR}"
+          echo "package_upload_dir=${UPLOAD_DIR}" >> "${GITHUB_OUTPUT}"
+      - name: Publish the downloaded wheels to PyPI
+        # zizmor: ignore[use-trusted-publishing]
+        run: |
+          python3 -m pip install 'twine>=6.2.0'
+          python3 -m twine upload -u __token__ "${UPLOAD_DIR}"/*
+        env:
+          UPLOAD_DIR: ${{ steps.download-wheels.outputs.package_upload_dir }}
+          TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,6 +13,9 @@ on:
       nightly_wheel_token:
         required: true
         description: "API token for publishing to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
+      pypi-token:
+        required: false
+        description: "API token for publishing to pypi.org"
 
 permissions: {}
 
@@ -179,7 +182,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
   publish:
-    if: ${{ inputs.publish_packages == 'true' }}
+    # TODO: revert this after 1.20.0 is published
+    # if: ${{ inputs.publish_packages == 'true' }}
     needs: test
     runs-on: linux-amd64-cpu4
     container:
@@ -217,4 +221,4 @@ jobs:
           python3 -m twine upload -u __token__ "${UPLOAD_DIR}"/*
         env:
           UPLOAD_DIR: ${{ steps.download-wheels.outputs.package_upload_dir }}
-          TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.pypi-token }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -6,9 +6,8 @@ on:
         required: true
         type: string
       publish_packages:
-        required: false
-        default: 'false'
-        type: string
+        required: true
+        type: boolean
     secrets:
       nightly_wheel_token:
         required: true
@@ -182,9 +181,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
   publish:
-    # TODO: revert this after 1.20.0 is published
-    # if: ${{ inputs.publish_packages == 'true' }}
-    needs: build
+    if: ${{ inputs.publish_packages }}
+    needs: test
     runs-on: linux-amd64-cpu4
     container:
       image: "rapidsai/ci-wheel:latest" # zizmor: ignore[unpinned-images]

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -184,7 +184,7 @@ jobs:
   publish:
     # TODO: revert this after 1.20.0 is published
     # if: ${{ inputs.publish_packages == 'true' }}
-    # needs: test
+    needs: build
     runs-on: linux-amd64-cpu4
     container:
       image: "rapidsai/ci-wheel:latest" # zizmor: ignore[unpinned-images]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,6 @@ jobs:
     uses: ./.github/workflows/build_and_test.yaml
     with:
       build_type: pull-request
-      publish_packages: true
+      publish_packages: false
     secrets:
       nightly_wheel_token: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
-      pypi-token: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,5 +39,7 @@ jobs:
     uses: ./.github/workflows/build_and_test.yaml
     with:
       build_type: pull-request
+      publish_packages: true
     secrets:
       nightly_wheel_token: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      pypi-token: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}


### PR DESCRIPTION
Merging a PR to `main` that changes `VERSION` automatically results in new wheels being built and uploaded to the RAPIDS nightly index (https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/).

But after that. uploads to `pypi.org` have historically been done manually.

This automates uploads to `pypi.org` too.

## Notes for Reviewers

### How I tested this

Did a real upload of v1.20.0 by temporarily allowing uploads from this branch. See https://github.com/rapidsai/ucx-wheels/pull/44#discussion_r3721871712