### PR TITLE
fix build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/build_and_test.yaml
     with:
       build_type: branch
-      publish_packages: ${{ needs.version_changed.outputs.version_changed }}
+      publish_packages: ${{ needs.version_changed.outputs.version_changed == 'true' }}
     secrets:
       nightly_wheel_token: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       pypi-token: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}


### PR DESCRIPTION
Fixes a small issue in #42 

`build.yaml` workflow is failing like this:

> _evaluate reusable workflow inputs: .github/workflows/build.yaml (Line: 45, Col: 25): Unexpected value 'false'_

https://github.com/rapidsai/ucx-wheels/actions/runs/31025644711

Job outputs in GitHub Actions are string, so an expression like `${{ needs.version_changed.outputs.version_changed }}` evaluates to `"false"` (a string) not `false` (a boolean).

This fixes that.