### PR TITLE
remove unused 'rapids-date-string' in build scripts

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 package_dir="python/libucx"
 
 source rapids-configure-sccache
-source rapids-date-string
 
 python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -v --no-deps --disable-pip-version-check
 


### PR DESCRIPTION
`rapids-date-string` is used to set the environment variable `RAPIDS_DATE_STRING`, which is not used here.

It's included in a wheel script here, probably as an accident from copying patterns from RAPIDS projects.

This removes it.

## Notes for Reviewers

Noticed this because as part of https://github.com/rapidsai/build-planning/issues/218, I'm removing `rapids-date-string` (https://github.com/rapidsai/gha-tools/pull/272). This prevents that change from breaking CI.